### PR TITLE
Fix suggested by Clippy

### DIFF
--- a/src/table_of_contents.rs
+++ b/src/table_of_contents.rs
@@ -29,7 +29,7 @@ pub fn find_table_of_content(text: &String) -> Vec<LineOfContents> {
         section = find_lines(&mut table_section, simple_line_regex.clone());
         parse_lines(&mut res, simple_line_regex, &mut section);
     } else {
-        section = find_lines(&mut table_section, no_dots_line_regex.clone());
+        section = find_lines(&mut table_section, no_dots_line_regex);
         parse_lines(&mut res, simple_line_regex, &mut section);
     }
     res


### PR DESCRIPTION
Fix suggested by static analysis tool:

warning: redundant clone
  --> src\table_of_contents.rs:32:68
   |
32 |         section = find_lines(&mut table_section, no_dots_line_regex.clone());
   |                                                                    ^^^^^^^^ help: remove this
   |
   = note: `#[warn(clippy::redundant_clone)]` on by default

Fix tested locally and seems to be working fine